### PR TITLE
Made views reflect the config.

### DIFF
--- a/app/views/devise_otp/credentials/show.html.erb
+++ b/app/views/devise_otp/credentials/show.html.erb
@@ -17,7 +17,7 @@
     </p>
 
   <%- if !@recovery && trusted_devices_enabled? %>
-    <p><%= f.label :trust_device, I18n.t('trust_device', {:scope => 'devise.otp.submit_token'}) %>
+    <p><%= f.label :trust_device, I18n.t('trust_device', {:scope => 'devise.otp.submit_token', :days => resource_class.otp_trust_persistence_days}) %>
         <%= f.check_box :trust_device, :autocomplete => :off, :checked => false %>
     </p>
   <% end %>

--- a/app/views/devise_otp/tokens/_trusted_devices.html.erb
+++ b/app/views/devise_otp/tokens/_trusted_devices.html.erb
@@ -1,5 +1,5 @@
 <h3><%= I18n.t('title', {:scope => 'devise.otp.trusted_devices'}) %></h3>
-<p><%= I18n.t('explain', {:scope => 'devise.otp.trusted_devices'}) %></p>
+<p><%= I18n.t('explain', {:scope => 'devise.otp.trusted_devices', :days => resource_class.otp_trust_persistence_days}) %></p>
 <%- if is_otp_trusted_device_for? resource %>
   <p><em><%= I18n.t('device_trusted', {:scope => 'devise.otp.trusted_devices'}) %></em></p>
   <p><%= link_to I18n.t('trust_remove', {:scope => 'devise.otp.trusted_devices'}), persistence_otp_token_path_for(resource_name), :method => :post %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,7 +9,7 @@ en:
         recovery_prompt: 'Please enter your recovery code:'
         submit: 'Submit Token'
         recovery_link: "I don't have my device, I want to use a recovery code"
-        trust_device: "Trust this device"
+        trust_device: "Trust this device. Don't ask again (on this browser) for %{days} days."
 
       credentials:
         token_invalid: 'The token you provided was invalid.'
@@ -59,7 +59,7 @@ en:
 
       trusted_devices:
         title: 'Trusted Browsers'
-        explain: 'If you set your browser as trusted, you will not be asked to perform a 2-factors authentication when logging in from that browser, for a time of one month.'
+        explain: 'If you set your browser as trusted, you will not be asked to perform a 2-factors authentication when logging in from that browser, for a time of %{days} days.'
         device_trusted: 'Your browser is trusted.'
         device_not_trusted: 'Your browser is not trusted.'
         trust_remove: 'Remove this device from the list of trusted browsers'

--- a/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
+++ b/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
@@ -40,6 +40,10 @@ module Devise::Models
       def find_valid_otp_challenge(challenge)
         with_valid_otp_challenge(Time.now).where(:otp_session_challenge => challenge).first
       end
+
+      def otp_trust_persistence_days
+        self.otp_trust_persistence / 1.day
+      end
     end
 
     def time_based_otp

--- a/test/models/otp_authenticatable_test.rb
+++ b/test/models/otp_authenticatable_test.rb
@@ -119,4 +119,9 @@ class OtpAuthenticatableTest < ActiveSupport::TestCase
     assert u.valid_otp_recovery_token? recovery.fetch(2)
   end
 
+  test 'otp_trust_persistence_days should return the correct number of day' do
+    resource = User
+    assert_equal 30.days, User.otp_trust_persistence # the default
+    assert_equal 30, User.otp_trust_persistence_days
+  end
 end


### PR DESCRIPTION
trusted_persistence now reflected in the views.

  -- redmine refs #8524

```
32/32: [=================================================================================================================================================================================================================] 0.9/s 100% 00:00:24

Finished in 24.11656s
32 tests, 65 assertions, 0 failures, 0 errors, 0 skips
```
